### PR TITLE
Add eb list-solution-stack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Ebfly is a simple command line interface for [AWS ElasticBeanstalk](http://aws.a
 
 ebfly only support following platforms.
 
+- Docker
 - Node.js
 - PHP
 - Python
@@ -51,6 +52,7 @@ Documents for each command is available on [docs](./docs).
 - [app](./docs/app.md)
 - [env](./docs/env.md)
 - [config](./docs/config.md)
+- [eb](./docs/eb.md)
 
 ## Quick Start
 

--- a/docs/eb.md
+++ b/docs/eb.md
@@ -1,0 +1,20 @@
+# eb
+
+`eb` is a command for getting information about ElasticBeanstalk.
+
+## Subcommands
+
+- [list-solution-stacks](#list-solution-stacks)
+
+<a name="list-solution-stacks"></a>
+### list-solution-stacks
+
+List all available and supported [solution stacks](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html),
+
+```
+ebfly eb list-solution-stacks
+```
+
+#### Options
+
+None

--- a/lib/ebfly/cli.rb
+++ b/lib/ebfly/cli.rb
@@ -7,6 +7,7 @@ require_relative 'options'
 require_relative 'command/app'
 require_relative 'command/env'
 require_relative 'command/config'
+require_relative 'command/elasticbeanstalk'
 
 module Ebfly
   class CLI < Thor
@@ -23,5 +24,8 @@ module Ebfly
 
     desc "config SUBCOMMAND ...ARGS", "manage environment's config vars"
     subcommand "config", Config
+
+    desc "eb SUBCOMMAND ...ARGS", "Get information about ElasticBeanstalk"
+    subcommand "eb", ElasticBeanstalk
   end
 end

--- a/lib/ebfly/command/elasticbeanstalk.rb
+++ b/lib/ebfly/command/elasticbeanstalk.rb
@@ -1,0 +1,22 @@
+module Ebfly
+  class ElasticBeanstalk < Thor
+    include Command
+
+    desc "list-solution-stacks", "List available solution stacks"
+    def list_solution_stacks
+      ret = run { eb.list_available_solution_stacks() }
+      debug ret
+
+      SUPPORTED_SOLUTION_STACKS.each do |sss|
+        puts ""
+        puts "=== #{sss} ==="
+        stacks = ret[:solution_stacks].select do |ss|
+          supported = false
+          supported = true if ss.include? sss
+          supported
+        end
+        puts stacks.sort
+      end
+    end
+  end
+end

--- a/lib/ebfly/ebfly.rb
+++ b/lib/ebfly/ebfly.rb
@@ -17,6 +17,8 @@ module Ebfly
       "docker0.9" => "64bit Amazon Linux 2014.03 v1.0.5 running Docker 0.9.0"
     }
 
+    SUPPORTED_SOLUTION_STACKS = ['Docker', 'Node.js', 'PHP', 'Python', 'Ruby']
+
     def eb
       @eb ||= AWS::ElasticBeanstalk.new
       @eb.client


### PR DESCRIPTION
Fix #8.

Output is like this:

```
$ ebfly eb list-solution-stacks

=== Docker ===
64bit Amazon Linux 2014.03 v1.0.0 running Docker 1.0.0
64bit Amazon Linux 2014.03 v1.0.1 running Docker 1.0.0
64bit Amazon Linux 2014.03 v1.0.2 running Docker 0.9.0
64bit Amazon Linux 2014.03 v1.0.5 running Docker 0.9.0

=== Node.js ===
32bit Amazon Linux 2014.03 v1.0.3 running Node.js
64bit Amazon Linux 2014.03 v1.0.3 running Node.js
64bit Amazon Linux 2014.03 v1.0.4 running Node.js

=== PHP ===
32bit Amazon Linux 2014.03 v1.0.3 running PHP 5.4
32bit Amazon Linux 2014.03 v1.0.3 running PHP 5.5
32bit Amazon Linux running PHP 5.3
64bit Amazon Linux 2014.03 v1.0.3 running PHP 5.4
64bit Amazon Linux 2014.03 v1.0.3 running PHP 5.5
64bit Amazon Linux 2014.03 v1.0.4 running PHP 5.4
64bit Amazon Linux 2014.03 v1.0.4 running PHP 5.5
64bit Amazon Linux running PHP 5.3

=== Python ===
32bit Amazon Linux 2014.03 v1.0.3 running Python
32bit Amazon Linux 2014.03 v1.0.3 running Python 2.7
32bit Amazon Linux running Python
64bit Amazon Linux 2014.03 v1.0.3 running Python
64bit Amazon Linux 2014.03 v1.0.3 running Python 2.7
64bit Amazon Linux 2014.03 v1.0.4 running Python
64bit Amazon Linux 2014.03 v1.0.4 running Python 2.7
64bit Amazon Linux running Python

=== Ruby ===
32bit Amazon Linux 2013.09 running Ruby 1.9.3
32bit Amazon Linux 2014.02 v1.0.1 running Ruby 1.8.7
32bit Amazon Linux 2014.03 v1.0.2 running Ruby 1.9.3
32bit Amazon Linux 2014.03 v1.0.3 running Ruby 1.9.3
32bit Amazon Linux running Ruby 1.8.7
32bit Amazon Linux running Ruby 1.9.3
64bit Amazon Linux 2013.09 running Ruby 1.9.3
64bit Amazon Linux 2014.02 v1.0.1 running Ruby 1.8.7
64bit Amazon Linux 2014.03 v1.0.2 running Ruby 1.9.3
64bit Amazon Linux 2014.03 v1.0.2 running Ruby 2.0 (Passenger Standalone)
64bit Amazon Linux 2014.03 v1.0.3 running Ruby 1.9.3
64bit Amazon Linux 2014.03 v1.0.3 running Ruby 2.0 (Passenger Standalone)
64bit Amazon Linux 2014.03 v1.0.3 running Ruby 2.0 (Puma)
64bit Amazon Linux 2014.03 v1.0.4 running Ruby 1.9.3
64bit Amazon Linux 2014.03 v1.0.4 running Ruby 2.0 (Passenger Standalone)
64bit Amazon Linux 2014.03 v1.0.4 running Ruby 2.0 (Puma)
64bit Amazon Linux 2014.03 v1.0.5 running Ruby 2.0 (Puma)
64bit Amazon Linux running Ruby 1.8.7
64bit Amazon Linux running Ruby 1.9.3
```
