### PR TITLE
Updated the namespace for environment.

### DIFF
--- a/lib/ebfly/options.rb
+++ b/lib/ebfly/options.rb
@@ -12,7 +12,7 @@ module Ebfly
       "vpc" => "aws:ec2:vpc",
       "application" => "aws:elasticbeanstalk:application",
       "command" => "aws:elasticbeanstalk:command",
-      "environment" => "aws:elasticbeanstalk:environment",
+      "environment" => "aws:elasticbeanstalk:application:environment",
       "monitoring" => "aws:elasticbeanstalk:monitoring",
       "topics" => "aws:elasticbeanstalk:sns:topics",
       "sqsd" => "aws:elasticbeanstalk:sqsd",


### PR DESCRIPTION
It is exception when try to update environment options.

``` shell
$ ebfly env update web -a docker -o environment-RDS_DB_NAME=rds_db_name
ERR! Configuration validation exception: Invalid parameter value (Namespace: 'aws:elasticbeanstalk:environment', OptionName: 'RDS_DB_NAME'): Unknown configuration setting.
```
