### PR TITLE
Lock aws-sdk < 2.0, because backward compatibility

### DIFF
--- a/ebfly.gemspec
+++ b/ebfly.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", ">= 1.39.0"
+  # http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2
+  spec.add_runtime_dependency "aws-sdk", "< 2.0"
   spec.add_runtime_dependency "thor"
 end


### PR DESCRIPTION
For http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2.

AWS SDK v2 is released but it has no compatibility to v1.
So for now, I lock aws-sdk version to v1.